### PR TITLE
Port Ayarı Hk.

### DIFF
--- a/Initia/Oracle.md
+++ b/Initia/Oracle.md
@@ -16,7 +16,7 @@ mv build/slinky /usr/local/bin/
 ```
 echo "$(curl -s ifconfig.me)$(grep -A 6 "\[grpc\]" ~/.initia/config/app.toml | egrep -o ":[0-9]+")"
 ```
-### Servis dosyanızdaki port kısmına değişken olarak ayarlayın
+### Servis dosyanızdaki port kısmına değişken atayın
 ```
 PORT=GRPC_PORT_NUMARANIZI_YAZIN
 ```

--- a/Initia/Oracle.md
+++ b/Initia/Oracle.md
@@ -12,6 +12,14 @@ make build
 ```
 mv build/slinky /usr/local/bin/
 ```
+### Portunuzu kontrol edin
+```
+echo "$(curl -s ifconfig.me)$(grep -A 6 "\[grpc\]" ~/.initia/config/app.toml | egrep -o ":[0-9]+")"
+```
+### Servis dosyanızdaki port kısmına değişken olarak ayarlayın
+```
+PORT=GRPC_PORT_NUMARANIZI_YAZIN
+```
 ### Servis olusturalım
 ```
 sudo tee /etc/systemd/system/slinkyd.service > /dev/null <<EOF
@@ -21,7 +29,7 @@ After=network-online.target
 
 [Service]
 User=$USER
-ExecStart=$(which slinky) --oracle-config-path $HOME/slinky/config/core/oracle.json --market-map-endpoint 127.0.0.1:15090
+ExecStart=$(which slinky) --oracle-config-path $HOME/slinky/config/core/oracle.json --market-map-endpoint 127.0.0.1:$PORT
 Restart=on-failure
 RestartSec=30
 LimitNOFILE=65535


### PR DESCRIPTION
Rehberde, servis dosyasındaki port 15090 olarak belirtilmiş, ancak bu port Oracle'ın her kullanıcıda doğru çalışmasını garanti etmez. Herkesin 15090 portunu kullandığı varsayımı doğru değildir; genellikle varsayılan port 9090'dır. Ancak varsayılan portun kullanımı da her zaman doğru değildir; port değiştirmiş kullanıcıların buna göre düzenleme yapması gerekmektedir.

Bu nedenle, her kullanıcının öncelikle kendi portunu belirlemesi ve bu portu bir değişken aracılığıyla servis dosyasına eklemesi gerekir. Aksi takdirde, Oracle'ın çalıştığını düşünseler bile, port uyumsuzluğu nedeniyle Oracle düzgün çalışmayacaktır.